### PR TITLE
Fix readiness probe for vault v1.3.0

### DIFF
--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.9.1
+version: 0.9.2
 appVersion: 1.2.3
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/charts/vault/templates/statefulset.yaml
+++ b/charts/vault/templates/statefulset.yaml
@@ -117,7 +117,7 @@ spec:
             {{ else }}
             scheme: HTTPS
             {{ end }}
-            path: /v1/sys/health?standbyok&perfstandbyok
+            path: /v1/sys/health?standbyok=true&perfstandbyok=true
             port: vault
         securityContext:
           readOnlyRootFilesystem: true

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -1234,7 +1234,7 @@ func statefulSetForVault(v *vaultv1alpha1.Vault, externalSecretsToWatchItems []c
 						HTTPGet: &corev1.HTTPGetAction{
 							Scheme: getVaultURIScheme(v),
 							Port:   intstr.FromString("api-port"),
-							Path:   "/v1/sys/health?standbyok&perfstandbyok",
+							Path:   "/v1/sys/health?standbyok=true&perfstandbyok=true",
 						}},
 					PeriodSeconds:    5,
 					FailureThreshold: 2,


### PR DESCRIPTION
Vaults health check parameters for standby changed in https://github.com/hashicorp/vault/issues/7323

| Q               | A
| --------------- | ---
| Bug fix?        | yes, when deploying with vault v1.3.0
| New feature?    | no
| API breaks?     | no (tested the change against v1.2.3)
| Deprecations?   | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Adds the boolean values to the vault readiness probe parameters `standbyok` and `perfstandbyok`.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
With https://github.com/hashicorp/vault/issues/7323 vault checks the actual value when those parameters are passed and doesn't default to true.

When you spin up a v1.3.0 vault cluster the first node will start normal, though the readiness probe for the second will fail since the parameters are not set properly for it to ignore standbys.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
Only needed when upgrading to vault v1.3.0.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Related Helm chart(s) updated (if needed)
